### PR TITLE
don't depend on drag&drop in demo

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -103,7 +103,7 @@ body {
 
 #controls {
 	position: relative;
-	top: 10em;
+	top: 14em;
 	text-align: center;
 }
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,14 @@
         });
       }
 
+      function loadFile(file) {
+        init();
+        player.load(file, function(buffer) {
+          document.querySelector(".loadedfile").innerHTML = file.name;
+          player.play(buffer);
+        });
+      }
+
       var fileaccess = document.querySelector("*");
       fileaccess.ondrop = function(e) {
         e.preventDefault();
@@ -58,7 +66,11 @@
         <span class="loadedfile">nothing loaded</span><br>
         <a onclick="player.togglePause()" id="pause" class="control"></a>
       </div>
-      <div id="demosong"><a onclick="loadURL('tunes/mysteristerium.mod')" herf="#">Load demo song<br>(mysterysterium by maktone)</a></div>
+      <div id="demosong"><a onclick="loadURL('tunes/mysteristerium.mod')" href="#">Load demo song<br>(mysterysterium by maktone)</a>
+      <br/>
+      <br /><input type="file" id="files" name="files" onchange="loadFile(this.files[0])"/>
+      <br/>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This enables the demo for those of us who don't have a desktop and can't "drop" anything on our browser windows.
This is a quick fix, you might not want to merge this code-duplicating version, but it works for me.
(I'm sad the libopenmpt version does work better than the libxmp one. :P )

On another note, your License file isn't actually the [X11](http://directory.fsf.org/wiki/License:X11), but the [Expat](https://directory.fsf.org/wiki/License:Expat) "MIT" license.
