### PR TITLE
Fix mem error

### DIFF
--- a/js/chiptune2.js
+++ b/js/chiptune2.js
@@ -87,11 +87,11 @@ ChiptuneJsPlayer.prototype.load = function(input, callback) {
 }
 
 ChiptuneJsPlayer.prototype.play = function(buffer) {
+  this.stop();
   var processNode = this.createLibopenmptNode(buffer, this.config);
   if (processNode == null) {
     return;
   }
-  this.stop();
   this.currentPlayingNode = processNode;
   processNode.connect(this.context.destination);
 }


### PR DESCRIPTION
Somtimes I have `openmpt_module_read_float_stereo: ERROR` and `memory allocation error` during playlist playing.   
So **before** creating new ScriptProcessor there is need to cleanup previously created with `stop()`