### PR TITLE
allow user to pass own context in config

### DIFF
--- a/js/chiptune2.js
+++ b/js/chiptune2.js
@@ -2,14 +2,15 @@
 ChiptuneAudioContext = AudioContext || webkitAudioContext;
 
 // config
-function ChiptuneJsConfig(repeatCount) {
+function ChiptuneJsConfig(repeatCount, context) {
   this.repeatCount = repeatCount;
+  this.context = context;
 }
 
 // player
 function ChiptuneJsPlayer(config) {
-  this.context = new ChiptuneAudioContext;
   this.config = config;
+  this.context = config.context || new ChiptuneAudioContext;
   this.currentPlayingNode = null;
   this.handlers = [];
 }


### PR DESCRIPTION
#19 This update will allow the user to pass his or her own audio context into chiptune2.js. This is useful when using multiple instances of chiptune2.js (e.g. for sound effects) and/or using chiptune2.js with other audio libraries, so each instance and library may share just one context.

## Usage
```
var audioCtx = new AudioContext();
var player = new ChiptuneJsPlayer(new ChiptuneJsConfig(-1, audioCtx));
```