### PR TITLE
Fix for latest emscripten

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Chiptune.js
 #### Version 2
 
-This is a javascript library that can play module music files. It is based on the [libopenmpt](http://lib.openmpt.org/libopenmpt) C/C++ library. To translate libopenmpt into Javascript [emscripten](https://github.com/kripken/emscripten) was used. For audio output inside the browser WebAudio API ist used.
+This is a javascript library that can play module music files. It is based on the [libopenmpt](https://lib.openmpt.org/libopenmpt) C/C++ library. To translate libopenmpt into Javascript [emscripten](https://github.com/kripken/emscripten) was used. For audio output inside the browser WebAudio API ist used.
 
-**Please note**: The compiled `libopenmpt.js` in this repository is based on an outdated version of libopenmpt. Newer versions contain bugfixes and other improvements. Download the latest version from the libopenmpt developers [here](https://builds.openmpt.org/builds/auto/libopenmpt/dev.js/) and replace `libopenmpt.js.mem` and `libopenmpt.js`.  
+**Please note**: The compiled `libopenmpt.js` in this repository is based on an outdated version of libopenmpt. Newer versions contain bugfixes and other improvements. Download the latest version from the libopenmpt developers [here](https://lib.openmpt.org/libopenmpt/download/) and replace `libopenmpt.js.mem` and `libopenmpt.js`.  
 If you prefer to compile `libopenmpt.js` yourself (to save space or make custom changes) follow the instructions in the "Development" section.
 
 ## Features
@@ -25,13 +25,13 @@ If you prefer to compile `libopenmpt.js` yourself (to save space or make custom 
  
 ## Demo
 
-See it in action [here](http://deskjet.github.io/chiptune2.js/).
+See it in action [here](https://deskjet.github.io/chiptune2.js/).
 
-Just drop a module (e.g. from [modarchive.org](http://modarchive.org)) on the demo page and enjoy.
+Just drop a module (e.g. from [modarchive.org](https://modarchive.org)) on the demo page and enjoy.
 
 ## Development
-Download the latest [emscripten](https://emscripten.org) SDK. Follow the instructions for your OS. Make sure `emcc` and `em++` commands are available in the PATH.  
-Next download and extract the libopenmpt source code (unix like) from http://lib.openmpt.org/libopenmpt/.  
+Download the latest [emscripten](https://emscripten.org/) SDK. Follow the instructions for your OS. Make sure `emcc` and `em++` commands are available in the PATH.  
+Next download and extract the libopenmpt source code (unix like) from https://lib.openmpt.org/libopenmpt/.  
 Use this command inside the libopenmpt source folder to build:
 
     make CONFIG=emscripten

--- a/chiptune2.js
+++ b/chiptune2.js
@@ -47,18 +47,18 @@ ChiptuneJsPlayer.prototype.onError = function (handler) {
 
 // metadata
 ChiptuneJsPlayer.prototype.duration = function() {
-  return Module._openmpt_module_get_duration_seconds(this.currentPlayingNode.modulePtr);
+  return libopenmpt._openmpt_module_get_duration_seconds(this.currentPlayingNode.modulePtr);
 }
 
 ChiptuneJsPlayer.prototype.metadata = function() {
   var data = {};
-  var keys = Module.Pointer_stringify(Module._openmpt_module_get_metadata_keys(this.currentPlayingNode.modulePtr)).split(';');
+  var keys = Pointer_stringify(libopenmpt._openmpt_module_get_metadata_keys(this.currentPlayingNode.modulePtr)).split(';');
   var keyNameBuffer = 0;
   for (var i = 0; i < keys.length; i++) {
-    keyNameBuffer = Module._malloc(keys[i].length + 1);
-    Module.writeStringToMemory(keys[i], keyNameBuffer);
-    data[keys[i]] = Module.Pointer_stringify(Module._openmpt_module_get_metadata(this.currentPlayingNode.modulePtr, keyNameBuffer));
-    Module._free(keyNameBuffer);
+    keyNameBuffer = libopenmpt._malloc(keys[i].length + 1);
+    libopenmpt.writeAsciiToMemory(keys[i], keyNameBuffer);
+    data[keys[i]] = Pointer_stringify(libopenmpt._openmpt_module_get_metadata(this.currentPlayingNode.modulePtr, keyNameBuffer));
+    libopenmpt._free(keyNameBuffer);
   }
   return data;
 }
@@ -121,7 +121,7 @@ ChiptuneJsPlayer.prototype.play = function(buffer) {
   }
 
   // set config options on module
-  Module._openmpt_module_set_repeat_count(processNode.modulePtr, this.config.repeatCount);
+  libopenmpt._openmpt_module_set_repeat_count(processNode.modulePtr, this.config.repeatCount);
 
   this.currentPlayingNode = processNode;
   processNode.connect(this.context.destination);
@@ -149,23 +149,23 @@ ChiptuneJsPlayer.prototype.createLibopenmptNode = function(buffer, config) {
   processNode.config = config;
   processNode.player = this;
   var byteArray = new Int8Array(buffer);
-  var ptrToFile = Module._malloc(byteArray.byteLength);
-  Module.HEAPU8.set(byteArray, ptrToFile);
-  processNode.modulePtr = Module._openmpt_module_create_from_memory(ptrToFile, byteArray.byteLength, 0, 0, 0);
+  var ptrToFile = libopenmpt._malloc(byteArray.byteLength);
+  libopenmpt.HEAPU8.set(byteArray, ptrToFile);
+  processNode.modulePtr = libopenmpt._openmpt_module_create_from_memory(ptrToFile, byteArray.byteLength, 0, 0, 0);
   processNode.paused = false;
-  processNode.leftBufferPtr  = Module._malloc(4 * maxFramesPerChunk);
-  processNode.rightBufferPtr = Module._malloc(4 * maxFramesPerChunk);
+  processNode.leftBufferPtr  = libopenmpt._malloc(4 * maxFramesPerChunk);
+  processNode.rightBufferPtr = libopenmpt._malloc(4 * maxFramesPerChunk);
   processNode.cleanup = function() {
     if (this.modulePtr != 0) {
-      Module._openmpt_module_destroy(this.modulePtr);
+      libopenmpt._openmpt_module_destroy(this.modulePtr);
       this.modulePtr = 0;
     }
     if (this.leftBufferPtr != 0) {
-      Module._free(this.leftBufferPtr);
+      libopenmpt._free(this.leftBufferPtr);
       this.leftBufferPtr = 0;
     }
     if (this.rightBufferPtr != 0) {
-      Module._free(this.rightBufferPtr);
+      libopenmpt._free(this.rightBufferPtr);
       this.rightBufferPtr = 0;
     }
   }
@@ -207,14 +207,14 @@ ChiptuneJsPlayer.prototype.createLibopenmptNode = function(buffer, config) {
     var error = false;
     while (framesToRender > 0) {
       var framesPerChunk = Math.min(framesToRender, maxFramesPerChunk);
-      var actualFramesPerChunk = Module._openmpt_module_read_float_stereo(this.modulePtr, this.context.sampleRate, framesPerChunk, this.leftBufferPtr, this.rightBufferPtr);
+      var actualFramesPerChunk = libopenmpt._openmpt_module_read_float_stereo(this.modulePtr, this.context.sampleRate, framesPerChunk, this.leftBufferPtr, this.rightBufferPtr);
       if (actualFramesPerChunk == 0) {
         ended = true;
         // modulePtr will be 0 on openmpt: error: openmpt_module_read_float_stereo: ERROR: module * not valid or other openmpt error
         error = !this.modulePtr;
       }
-      var rawAudioLeft = Module.HEAPF32.subarray(this.leftBufferPtr / 4, this.leftBufferPtr / 4 + actualFramesPerChunk);
-      var rawAudioRight = Module.HEAPF32.subarray(this.rightBufferPtr / 4, this.rightBufferPtr / 4 + actualFramesPerChunk);
+      var rawAudioLeft = libopenmpt.HEAPF32.subarray(this.leftBufferPtr / 4, this.leftBufferPtr / 4 + actualFramesPerChunk);
+      var rawAudioRight = libopenmpt.HEAPF32.subarray(this.rightBufferPtr / 4, this.rightBufferPtr / 4 + actualFramesPerChunk);
       for (var i = 0; i < actualFramesPerChunk; ++i) {
         outputL[framesRendered + i] = rawAudioLeft[i];
         outputR[framesRendered + i] = rawAudioRight[i];

--- a/chiptune2.js
+++ b/chiptune2.js
@@ -56,7 +56,7 @@ ChiptuneJsPlayer.prototype.metadata = function() {
   var keyNameBuffer = 0;
   for (var i = 0; i < keys.length; i++) {
     keyNameBuffer = libopenmpt._malloc(keys[i].length + 1);
-    libopenmpt.writeAsciiToMemory(keys[i], keyNameBuffer);
+    writeAsciiToMemory(keys[i], keyNameBuffer);
     data[keys[i]] = Pointer_stringify(libopenmpt._openmpt_module_get_metadata(this.currentPlayingNode.modulePtr, keyNameBuffer));
     libopenmpt._free(keyNameBuffer);
   }


### PR DESCRIPTION
`Module` is no longer exported (and we added our own export, `libopenmpt`, a long while ago), plus `writeStringToMemory` got deprecated (and `writeAsciiToMemory` is enough for what we do here).