### PR TITLE
Added methods to get current row, pattern # & pattern in playing order

### DIFF
--- a/chiptune2.js
+++ b/chiptune2.js
@@ -50,6 +50,18 @@ ChiptuneJsPlayer.prototype.duration = function() {
   return libopenmpt._openmpt_module_get_duration_seconds(this.currentPlayingNode.modulePtr);
 }
 
+ChiptuneJsPlayer.prototype.getCurrentRow = function() {
+  return libopenmpt._openmpt_module_get_current_row(this.currentPlayingNode.modulePtr);  
+}
+
+ChiptuneJsPlayer.prototype.getCurrentPattern = function() {
+  return libopenmpt._openmpt_module_get_current_pattern(this.currentPlayingNode.modulePtr);  
+}
+
+ChiptuneJsPlayer.prototype.getCurrentOrder = function() {
+  return libopenmpt._openmpt_module_get_current_order(this.currentPlayingNode.modulePtr);  
+}
+
 ChiptuneJsPlayer.prototype.metadata = function() {
   var data = {};
   var keys = Pointer_stringify(libopenmpt._openmpt_module_get_metadata_keys(this.currentPlayingNode.modulePtr)).split(';');


### PR DESCRIPTION
This PR adds methods to:
- Get the current row of a playing pattern
- Get the current pattern number
- Get the current pattern number (in order)

For discussion, unsure about the naming as both snake case & lower camel case have been used. Also it's duration and not getDuration.