### PR TITLE
Add methods to enable displaying progress

### DIFF
--- a/chiptune2.js
+++ b/chiptune2.js
@@ -68,6 +68,10 @@ ChiptuneJsPlayer.prototype.getCurrentOrder = function() {
   return libopenmpt._openmpt_module_get_current_order(this.currentPlayingNode.modulePtr);  
 }
 
+ChiptuneJsPlayer.prototype.getCurrentTime = function () {
+  return libopenmpt._openmpt_module_get_position_seconds(this.currentPlayingNode.modulePtr);
+};
+
 ChiptuneJsPlayer.prototype.metadata = function() {
   var data = {};
   var keys = UTF8ToString(libopenmpt._openmpt_module_get_metadata_keys(this.currentPlayingNode.modulePtr)).split(';');

--- a/chiptune2.js
+++ b/chiptune2.js
@@ -72,6 +72,14 @@ ChiptuneJsPlayer.prototype.getCurrentTime = function () {
   return libopenmpt._openmpt_module_get_position_seconds(this.currentPlayingNode.modulePtr);
 };
 
+ChiptuneJsPlayer.prototype.getTotalOrder = function () {
+  return libopenmpt._openmpt_module_get_num_orders(this.currentPlayingNode.modulePtr);
+};
+
+ChiptuneJsPlayer.prototype.getTotalPatterns = function () {
+  return libopenmpt._openmpt_module_get_num_patterns(this.currentPlayingNode.modulePtr);
+};
+
 ChiptuneJsPlayer.prototype.metadata = function() {
   var data = {};
   var keys = UTF8ToString(libopenmpt._openmpt_module_get_metadata_keys(this.currentPlayingNode.modulePtr)).split(';');


### PR DESCRIPTION
add basic methods for displaying mod progress.

known issue: when mod repeats it will go beyond duration, probably correct though.

fixes: a tiny step towards https://github.com/deskjet/chiptune2.js#to-do